### PR TITLE
fix: torchmetrics import issue

### DIFF
--- a/Dockerfile.Lite
+++ b/Dockerfile.Lite
@@ -33,6 +33,7 @@ RUN sed -i -e '''/    prepare_environment()/a\    os.system\(f\"""sed -i -e ''\"
 RUN sed -i -e 's/fastapi==0.90.1/fastapi==0.89.1/g' /content/stable-diffusion-webui/requirements_versions.txt
 RUN sed -i -e 's/    start()/    #start()/g' /content/stable-diffusion-webui/launch.py
 RUN cd stable-diffusion-webui && python launch.py --skip-torch-cuda-test
+RUN pip install torchmetrics==0.11.4
 
 ADD --chown=user https://huggingface.co/ckpt/sd15/resolve/main/v1-5-pruned-emaonly.ckpt /content/stable-diffusion-webui/models/Stable-diffusion/v1-5-pruned-emaonly.ckpt
 


### PR DESCRIPTION
A specific version of torchmetrics is needed to avoid this issue from stable-diffusion-webui:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/11648

I added the workaround to Dockerfile.Lite as I know it was necessary but haven't tried with Stable and Nightly; it might be necessary too.

Also I added it in one of the last steps for convenience but if storage space is an issue, it might not be the best idea.